### PR TITLE
bump min version of ExtUtils::MakeMaker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,7 +2,7 @@ use 5.006;
 use strict;
 use warnings;
 
-use ExtUtils::MakeMaker 6.31; # XXX yes, that's not a nice thing to do
+use ExtUtils::MakeMaker 6.46; # XXX yes, that's not a nice thing to do
 
 # one of Term::Size, Term::Size::Perl, Term::Size::ReadKey, 
 # or Term::Size::Win32 should be available


### PR DESCRIPTION
Hi Adriano,

I started off wanting to do a PR to get the github repo in the dist metadata. But I see that's already done in your working version.

I've bumped the min version of ExtUtils::MakeMaker that was specified. There's a bugfix in 6.46 that's required for this.

Any chance you could do a release to CPAN, so the version on CPAN would have the github repo URL in the metadata? With that, metacpan.org would include a link to the repo in the sidebar, and other tools in the CPAN ecosystem would pick it up as well.

Cheers,
Neil