### PR TITLE
allow calling fully qualified functions before import is run

### DIFF
--- a/lib/Term/Size/Any.pm
+++ b/lib/Term/Size/Any.pm
@@ -6,12 +6,15 @@ use vars qw( $VERSION );
 
 $VERSION = '0.002';
 
+my $PACKAGE;
+
 sub _require_any {
-    my $package;
+    return $PACKAGE
+        if $PACKAGE;
 
     if ( $^O eq 'MSWin32' ) {
         require Term::Size::Win32;
-        $package = 'Term::Size::Win32';
+        $PACKAGE = 'Term::Size::Win32';
 
     } else {
         #require Best;
@@ -19,11 +22,12 @@ sub _require_any {
         #Best->import( @modules );
         #$package = Best->which( @modules );
         require Term::Size::Perl;
-        $package = 'Term::Size::Perl';
+        $PACKAGE = 'Term::Size::Perl';
 
     }
-    $package->import( qw( chars pixels ) ); # allows Term::Size::Any::chars
-    return $package;
+
+    $PACKAGE->import( qw( chars pixels ) ); # allows Term::Size::Any::chars
+    return $PACKAGE;
 }
 
 sub import {
@@ -32,6 +36,16 @@ sub import {
     unshift @_, $package;
     my $import_sub = $package->can('import');
     goto &$import_sub;
+}
+
+sub chars {
+    _require_any;
+    goto &chars;
+}
+
+sub pixels {
+    _require_any;
+    goto &pixels;
 }
 
 1;

--- a/t/03fully-qualified.t
+++ b/t/03fully-qualified.t
@@ -1,0 +1,46 @@
+
+use Test::More tests => 16;
+
+use Term::Size::Any ();
+
+my @handles = (
+    # name args handle
+    [ 'implicit STDIN', [], *STDIN ], # default: implicit STDIN
+    [ 'STDIN', [*STDIN], *STDIN ],
+    [ 'STDERR', [*STDERR], *STDERR ],
+    [ 'STDOUT', [*STDOUT], *STDOUT ],
+);
+
+for (@handles) {
+    my $h_name = $_->[0];
+    my @args = @{$_->[1]};
+    my $h = $_->[2];
+
+    SKIP: {
+    skip "$h_name is not tty", 4 unless -t $h;
+
+    my @chars = Term::Size::Any::chars @args;
+    is(scalar @chars, 2, "$h_name: chars return (cols, rows) - $h_name");
+
+    my $cols = Term::Size::Any::chars @args;
+    is($cols, $chars[0], "$h_name: chars return cols");
+
+    my @pixels = Term::Size::Any::pixels @args;
+    is(scalar @pixels, 2, "$h_name: pixels return (x, y)");
+
+    my $x = Term::Size::Any::pixels @args;
+    is($x, $pixels[0], "$h_name: pixels return x");
+
+  }
+
+}
+
+if (-t STDIN) {
+    # this is not at test, only a show-off
+    my @chars = Term::Size::Any::chars;
+    my @pixels = Term::Size::Any::pixels;
+    diag("This terminal is $chars[0]x$chars[1] characters,"
+         . " and $pixels[0]x$pixels[1] pixels."
+    );
+
+}


### PR DESCRIPTION
If nobody calls import, the chars and pixels functions wouldn't be
available to be called fully qualified.  Add those subs, which will load
the appropriate module and replace itself, then go to the new function.

Another way this could be done would be to load and import the functions at compile time, which would probably simplify the entire module.